### PR TITLE
商品一覧表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    # @items = Item.all
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action:authenticate_user!, except: :index
+  before_action :authenticate_user!, except: :index
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,21 +1,21 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
 
-with_options presence:true do
-  validates :image
-  validates :item_name,length: { maximum: 40 }
-  validates :item_discription, length: { maximum: 1000 }
-  
-  with_options numericality: {other_than: 1} do
-    validates :category_id 
-    validates :condition_id
-    validates :shipping_charge_id
-    validates :processing_time_id
-  end
+  with_options presence: true do
+    validates :image
+    validates :item_name, length: { maximum: 40 }
+    validates :item_discription, length: { maximum: 1000 }
 
-  validates :prefecture_id, numericality: { other_than: 0 }
-  validates :price, format: { with: /\d+/ }, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
-end
+    with_options numericality: { other_than: 1 } do
+      validates :category_id
+      validates :condition_id
+      validates :shipping_charge_id
+      validates :processing_time_id
+    end
+
+    validates :prefecture_id, numericality: { other_than: 0 }
+    validates :price, format: { with: /\d+/ }, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+  end
 
   has_one_attached :image
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
-  with_options presence:true do
-    validates_format_of :password, {with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze }
+
+  with_options presence: true do
+    validates_format_of :password, { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze }
     validates :nickname
 
     with_options format: { with: /\A[ぁ-んァ-ン一-龥]+\z/ } do
@@ -17,10 +17,10 @@ class User < ApplicationRecord
       validates :last_name_kana
       validates :first_name_kana
     end
-    
-   validates :birth_date 
+
+    validates :birth_date
   end
-  
+
   has_many :items
   has_many :purchases
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -159,9 +159,10 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @item = nil%>
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <%= image_tag "furima-intro04.png", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
             商品を出品してね！
@@ -176,6 +177,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,6 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -155,11 +154,9 @@
         <% end %>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <% if @item = nil%>
+      <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "furima-intro04.png", class: "item-img" %>
@@ -178,7 +175,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,7 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
+      <% if @items.exists? %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -156,7 +156,7 @@
       </li>
 
       <%# 商品がない場合のダミー %>
-      <% if @items.empty? %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "furima-intro04.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,14 +123,15 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,16 +142,17 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+        <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -68,7 +68,7 @@ describe Item do
         expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it 'priceが¥9,999,999以上だと出品できない' do
-        @item.price = 100000000
+        @item.price = 100_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end


### PR DESCRIPTION
「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」**以外**の実装を完了しました
### 以下機能の画像とgif

商品一覧表示
https://gyazo.com/412d80c7eb99aaa11d05818da5665a1c
上から、出品された日時が新しい順に表示されること
https://gyazo.com/252a938864879306b41c63e70709ad5f
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/fbf51c1f14a08f42b0b3a4c86a162edf