### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
   def index
     @items = Item.all.order('created_at DESC')
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
       <% if @items.exists? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,4 +1,4 @@
-<%= render "shared/header" %>
+<%= render "devise/shared/header" %>
 
 <%# 商品の概要 %>
 <div class="item-show">
@@ -105,4 +105,4 @@
   <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
 </div>
 
-<%= render "shared/footer" %>
+<%= render "devise/shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+         <%= "¥#{@item.price.to_s(:delimited, delimiter: ',')}" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+         <%= @item.shipping_charge.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -103,7 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "devise/shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,19 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+<% if user_signed_in? %>
+  <% if current_user == @item.user %>
+    <%#  商品編集削除ボタン %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+  
+  <% elsif '商品が出品中かどうか' %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+ <% end %>
+<% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,7 +38,7 @@
 <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_discription %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -43,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.processing_time.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
   resources :users, only: :show
 end


### PR DESCRIPTION
# What
商品詳細表示機能機能の作成

# Why
商品の詳細情報を表示するため

-----------------------------------------------------------------------------------------------------------------------------
「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」以外の実装を完了しました。
### 以下gifと画像です
- ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://gyazo.com/7dc72fa195fa04051baf20dcff0e0771
- ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/a89324029744dd6f3fea0e25b3f65179
- ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること、ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/ab9138c64b6afcb7dc241adc6ace86a8
- 商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/a39bc0eeb6d32657271ca2e1079256fa
https://gyazo.com/8928f9c3b3b1649536ccbcddd3dbbcf7